### PR TITLE
IdTypeForUser-attribute that defines the DC attribute used to identify the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The most relevant configuration entries are shown below. Make sure you make your
   1. `http://mypasscore.com/?userName=someusername`
   2. This helps the user incase they forgot thier username and, also comes in handy when sending a link to the application or having it embeded into another application were the user is all ready signed in.
 - To specify which (DC) attribute is used to search for the specific user.
-  - With the `IdentityType` can select one of six possible Attributes that will be used to searched for the user.
+  - With the `IdTypeForUser` it is possible to select one of six Attributes that will be used to search for the specifiv user.
   - The possible values are:
     - `DistinguishedName` or `DN`
     - `GloballyUniqueIdentifier` or `GUID`

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeOptions.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeOptions.cs
@@ -13,5 +13,6 @@
         public bool CheckRestrictedAdGroups { get; set; }
         public List<string> AllowedADGroups { get; set; }
         public bool CheckAllowedAdGroups { get; set; }
+        public string IdTypeForUser { get; set; }
     }
 }

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -19,7 +19,7 @@
         }
 
         /// <summary>
-        /// 
+        /// Use the values from appsettings.IdTypeForUser as fault-tolerant as possible
         /// </summary>
         private void SetIdType()
         {
@@ -141,6 +141,7 @@
                         }
                     }
 
+                    // Use always UPN for passwordcheck.
                     if (ValidateUserCredentials(userPrincipal.UserPrincipalName, currentPassword, principalContext) == false)
                         return new ApiErrorItem { ErrorCode = ApiErrorCode.InvalidCredentials };
 
@@ -169,13 +170,13 @@
             return null;
         }
 
-        private static bool ValidateUserCredentials(string username, string currentPassword, PrincipalContext principalContext)
+        private static bool ValidateUserCredentials(string upn, string currentPassword, PrincipalContext principalContext)
         {
-            if (principalContext.ValidateCredentials(username, currentPassword))
+            if (principalContext.ValidateCredentials(upn, currentPassword))
                 return true;
 
-            string tmpAuthority = username?.Split('@')?.Last();
-            if (LogonUser(username, tmpAuthority, currentPassword, LogonTypes.Network, LogonProviders.Default, out _))
+            string tmpAuthority = upn?.Split('@')?.Last();
+            if (LogonUser(upn, tmpAuthority, currentPassword, LogonTypes.Network, LogonProviders.Default, out _))
                 return true;
 
             var errorCode = System.Runtime.InteropServices.Marshal.GetLastWin32Error();

--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -141,7 +141,7 @@
                         }
                     }
 
-                    if (ValidateUserCredentials(username, currentPassword, principalContext) == false)
+                    if (ValidateUserCredentials(userPrincipal.UserPrincipalName, currentPassword, principalContext) == false)
                         return new ApiErrorItem { ErrorCode = ApiErrorCode.InvalidCredentials };
 
                     // Change the password via 2 different methods. Try SetPassword if ChangePassword fails.

--- a/src/Unosquare.PassCore.Web/ClientApp/app/footer/footer.html
+++ b/src/Unosquare.PassCore.Web/ClientApp/app/footer/footer.html
@@ -19,7 +19,7 @@
     </div>
     <div fxLayout="column" fxLayoutAlign="center">
         <div class="footer-text">
-            Powered by PassCore v3.1.0 - Open Source Initiative and MIT Licensed
+            Powered by PassCore v3.4.0 - Open Source Initiative and MIT Licensed
             <br> Copyright © 2018 Unosquare
         </div>
     </div>

--- a/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
+++ b/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
@@ -114,9 +114,9 @@ namespace Unosquare.PassCore.Web.Controllers
             var domain = parts.Length > 1 ? parts[1] : _options.ClientSettings.DefaultDomain;
 
             // Domain-determinance
-            if (string.IsNullOrEmpty(domain))
+            if (string.IsNullOrWhiteSpace(domain))
             {
-                result.Errors.Add(new ApiErrorItem { ErrorCode = ApiErrorCode.InvalidDomain });
+                return model.Username;
             }
 
             return parts.Length > 1 ? model.Username : $"{model.Username}@{domain}";

--- a/src/Unosquare.PassCore.Web/appsettings.json
+++ b/src/Unosquare.PassCore.Web/appsettings.json
@@ -20,7 +20,8 @@
       "Enterprise Admins"
     ],
     "CheckAllowedAdGroups": false,
-    "AllowedADGroups": []
+    "AllowedADGroups": [],
+    "IdTypeForUser": "DN" // possible values are "DN", "GUID", "Name", "SAM", "SID" and "UPN"
   },
   "LdapPasswordChangeOptions": {
     "LdapHostnames": [ "ldap-host.example.com" ],


### PR DESCRIPTION
Add another IdTypeForUser attribute in appsettings that defines the DC attribute used to identify the user based on the username.

```json
  "PasswordChangeOptions": {
 ...
    "IdTypeForUser": "DN" // possible values are "DN", "GUID", "Name", "SAM", "SID" and "UPN"
  }
```
If no IdTypeForUser is set, the UPN will be used (I'm not sure if this attribute was the Attribute that was used before)

this extension should fix the issues  #220 and #204.

But, I was not able to test those changes completely.
