### PR TITLE
[Add] Flag for SSL and adjust guards for TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ dotnet publish --configuration Release --runtime linux-x64 /p:PASSCORE_PROVIDER=
 dotnet publish --configuration Release --runtime osx-x64 /p:PASSCORE_PROVIDER=LDAP --output "<path>"
 ```
 
-*Note* - The `PASSCORE_PROVIDER` modifier will use the LDAP Provider instead of Activde Directory Provider.
+*Note* - The `PASSCORE_PROVIDER` modifier will use the LDAP Provider instead of Active Directory Provider.
 
 
 ## Create your own provider

--- a/src/Unosquare.PassCore.Web/appsettings.json
+++ b/src/Unosquare.PassCore.Web/appsettings.json
@@ -23,7 +23,8 @@
     "UpdateLastPassword": false, // Set true to allow PassCore to  update the last password timestamp
     // The following options are for LDAP Provider (remove if you don't use this Provider)
     "LdapSearchBase": "ou=people,dc=example,dc=com",
-    "LdapStartTls": false,
+    "LdapSecureSocketLayer": false, // Default for AD is true when using LDAPS 636
+    "LdapStartTls": false, // Default for AD is true when using LDAP 389
     "LdapChangePasswordWithDelAdd": true,
     "LdapSearchFilter": "(sAMAccountName={Username})", // Another value: "(&(objectClass=person)(cn={Username}))"
     // General options (valid for both providers)

--- a/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeOptions.cs
+++ b/src/Zyborg.PassCore.PasswordProvider.LDAP/LdapPasswordChangeOptions.cs
@@ -25,6 +25,18 @@ namespace Zyborg.PassCore.PasswordProvider.LDAP
         public int LdapPort { get; set; } = LdapConnection.DEFAULT_SSL_PORT;
 
         /// <summary>
+        /// Gets or sets a value indicating whether [LDAP uses SSL].
+        /// </summary>
+        /// <remarks>
+        /// Optional, if 'true', then the specified port is using SSL encryption.
+        /// By default this should set to 'true' when using port 636.
+        /// </remarks>
+        /// <value>
+        ///   <c>true</c> if [LDAP uses SSL]; otherwise, <c>false</c>.
+        /// </value>
+        public bool LdapSecureSocketLayer { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether [LDAP start TLS].
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
I have been working on getting this working with .NET Core and its been a bit of work. These are a the changes that I have added to get the system working correctly.

The problem was that when you enabled StartTLS it would also enable SSL.

- Connecting to 389 by default we should establish a plain text connection and then upgrade to TLS.
- Connecting to 636 by default we should start out with SSL and no TLS.

I have included new flags so that SSL can be turned on and off correctly.

