### PR TITLE
[Update] Dockerfile and Fix Guards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,24 @@
-ARG REPO=microsoft/dotnet
-FROM $REPO:2.2-runtime-deps-alpine3.8 as builder
+ARG DOTNET_VERSION=3.0
+FROM mcr.microsoft.com/dotnet/core/sdk:$DOTNET_VERSION-alpine3.9 AS build
 
 # Disable the invariant mode (set in base image)
 RUN apk add --no-cache \
     icu-libs \
-    nodejs=8.14.0-r0 \
+    nodejs=10.14.2-r0 \
     nodejs-npm
 
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8
+WORKDIR /build
 
-# Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.2.100
+COPY . .
 
-RUN wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='668dbbfdee1b898de57ee7320b3f7f77c3bae896cb1480d64869512f26d6998edccc1163c9ca6ed62b326e2d745a81e82a35a24cf4f7e11319fec0c6904e566e' \
-    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
-    && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz
-
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER=true \ 
-    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
-
-# Trigger first run experience by running arbitrary cmd to populate local package cache
-RUN dotnet help
-
-WORKDIR /app
-
-COPY . ./
 RUN dotnet restore
+RUN dotnet publish -c Release -o /publish /p:PASSCORE_PROVIDER=LDAP
 
-# Copy everything else and build
-RUN dotnet publish -c Release -o /app/out /p:PASSCORE_PROVIDER=LDAP
-
-FROM $REPO:2.2-runtime-deps-alpine3.8
-
-# Install ASP.NET Core
-ENV ASPNETCORE_VERSION 2.2.0
-
-RUN wget -O aspnetcore.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-musl-x64.tar.gz \
-    && aspnetcore_sha512='c297f7196b72e02ec41a5a0c027dcec1648ad552bf44036fa491d67d9b4f09e3ade84fd51ebffd68e8fa8077f2497ad851e13c83dac6aba89dd03f6df0adca6f' \
-    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
-    && mkdir -p /usr/share/dotnet \
-    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
-    && rm aspnetcore.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+FROM mcr.microsoft.com/dotnet/core/aspnet:$DOTNET_VERSION-alpine3.9 AS release
 
 WORKDIR /app
 
-COPY --from=builder /app/out .
+COPY --from=build /publish .
 
 EXPOSE 80
 CMD ["dotnet", "/app/Unosquare.PassCore.Web.dll"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ before_build:
 - cd ../../..
 build_script:
 - cmd: dotnet publish --configuration Release --runtime win-x64 --output "C:/passcore"
-- sh: dotnet publish --configuration Release --runtime linux-x64
+- sh: dotnet publish --configuration Release --runtime linux-x64 /p:PASSCORE_PROVIDER=LDAP
 - ps: |
         if($isWindows)
         {

--- a/src/Unosquare.PassCore.Web/Unosquare.PassCore.Web.csproj
+++ b/src/Unosquare.PassCore.Web/Unosquare.PassCore.Web.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes);**\node_modules\**;node_modules\**</DefaultItemExcludes>
     <Copyright>Copyright (c) 2018-2019 - Unosquare</Copyright>
@@ -15,7 +14,6 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
       <PrivateAssets>all</PrivateAssets>
@@ -27,7 +25,6 @@
     </PackageReference>
     <PackageReference Include="zxcvbn-core" Version="2.1.44" />
   </ItemGroup>
-
   <ItemGroup>
     <Content Remove="ClientApp\**" />
     <Content Include="ClientApp\package.json" />
@@ -37,26 +34,21 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Unosquare.PassCore.Common\Unosquare.PassCore.Common.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(RuntimeIdentifier)' != 'linux-x64'">
+  <ItemGroup Condition="'$(PASSCORE_PROVIDER)' == ''">
     <!-- Default Password Provider - Win32 -->
     <ProjectReference Include="..\Unosquare.PassCore.PasswordProvider\Unosquare.PassCore.PasswordProvider.csproj" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+  <ItemGroup Condition="'$(PASSCORE_PROVIDER)' == 'LDAP'">
     <!-- Pure LDAP provider -->
     <ProjectReference Include="..\Zyborg.PassCore.PasswordProvider.LDAP\Zyborg.PassCore.PasswordProvider.LDAP.csproj" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+  <PropertyGroup Condition="'$(PASSCORE_PROVIDER)' == 'LDAP'">
     <DefineConstants>PASSCORE_LDAP_PROVIDER</DefineConstants>
   </PropertyGroup>
-
-  <Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('.\ClientApp\package-lock.json')">
+  <Target Name="NpmInstall" BeforeTargets="Build" Condition="!Exists('.\ClientApp\node_modules')">
     <Exec Command="node --version" ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
     </Exec>
@@ -64,10 +56,8 @@
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
     <Message Importance="high" Text="Performing first-run npm install..." />
   </Target>
-
   <Target Name="Parcel" DependsOnTargets="NpmInstall" BeforeTargets="Build">
     <Message Importance="high" Text="Performing run Parcel build..." />
     <Exec Command="npm run build" WorkingDirectory=".\ClientApp" />
   </Target>
-
 </Project>


### PR DESCRIPTION
@geoperez 
This commit should be functional but I need to have the CI job run here to confirm functionality. Recently the build process was fixed by changing from a flag to runtime check. This normally would work alright but the Dockerfile is using alpine which is not `linux-x64` but `linux-musl-x64` I did try changing it but I would like to know which way we should go with this. Update the README.md with the changes and add support for checking multiple values in the csproj file.

https://github.com/unosquare/passcore/commit/6b69dfb5d092177db7cc73eaffd75c2b6cfcd868
https://github.com/unosquare/passcore/commit/80f7a24550e2633473cb3f0bc46916f6c72dcb32

I have updated to 3.0 as the runtime version and also cleaned up the Dockerfile to use the newer MS standard for Dockerfiles.
