### PR TITLE
Add useEffect hook to avoid multple executions after submitting

### DIFF
--- a/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePasswordForm.tsx
+++ b/src/Unosquare.PassCore.Web/ClientApp/Components/ChangePasswordForm.tsx
@@ -55,9 +55,11 @@ export const ChangePasswordForm: React.FunctionComponent<IChangePasswordFormProp
     const userNameErrorMessages = [fieldRequired, useEmail ? usernameEmailPattern : usernamePattern];
     const userNameHelperText = useEmail ? usernameHelpblock : usernameDefaultDomainHelperBlock;
 
-    if (submitData) {
-        toSubmitData(fields);
-    }
+    React.useEffect(() => {
+        if (submitData) {
+            toSubmitData(fields);
+        }
+    }, [submitData]);
 
     React.useEffect(() => {
         if (parentRef.current !== null && parentRef.current.isFormValid !== null) {


### PR DESCRIPTION
**PassCore Server**
- OS: Windows
- Provider: Active Directory

**Describe the intention of the PR** 
After submitting data there was a rendering in the control which provokes multiple submits and these re-render the same control entering into a loop; Added an userEffect to submit just when the variable submitData is modified.
