### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the [IIS setup script](https://raw.githubusercontent.com/unosquare/passcore/mast
 to execute the script.
 
 ## Linux
-We recommend use the docker image and redirect the traffic to ngix.
+We recommend use the docker image and redirect the traffic to nginx.
 
 ## Docker
 


### PR DESCRIPTION
**PassCore Server**
- OS: Windows
- Provider: Active Directory

**Describe the intention of the PR** 
This pull request fixes the typo in README.me that says ngix instead of nginx