### PR TITLE
Fix AllowedADGroups and captcha validation

### DIFF
--- a/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
+++ b/src/Unosquare.PassCore.PasswordProvider/PasswordChangeProvider.cs
@@ -179,7 +179,7 @@
                             "The User principal is listed as restricted");
                     }
 
-                return groups?.Any(x => _options.AllowedADGroups?.Contains(x.Name) == true) == true
+                return groups?.Any(x => _options.AllowedADGroups?.Contains(x.Name) != false) == true
                     ? null
                     : new ApiErrorItem(ApiErrorCode.ChangeNotPermitted, "The User principal is not listed as allowed");
             }

--- a/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
+++ b/src/Unosquare.PassCore.Web/Controllers/PasswordController.cs
@@ -142,7 +142,7 @@
             // skip validation if we don't enable recaptcha
             if ((_options.Recaptcha != null) && string.IsNullOrWhiteSpace(_options.Recaptcha.PrivateKey))
                 return true;
-            else if ((_options.Recaptcha != null) && (string.IsNullOrEmpty(recaptchaResponse) != false))
+            else if ((_options.Recaptcha != null) && (string.IsNullOrEmpty(recaptchaResponse) != true))
             {
                 var requestUrl = new Uri(
                     $"https://www.google.com/recaptcha/api/siteverify?secret={_options.Recaptcha.PrivateKey}&response={recaptchaResponse}");


### PR DESCRIPTION
PassCore Server

    OS: Windows
    Provider: Active Directory

Describe the intention of the PR
This PR fixes #602 as well as the AllowedADGroups check (when it is empty).